### PR TITLE
Fix issue parsing setup.cfg

### DIFF
--- a/lib/black_isort.py
+++ b/lib/black_isort.py
@@ -106,8 +106,9 @@ class Commands(object):
                     import configparser
 
                     config = configparser.ConfigParser()
-                    config.read_file(path)
-                    if config.has_section('tool:isort'):
+                    with open(path) as fp:
+                        config.read_file(fp)
+                    if config.has_section('isort') or config.has_section('tool:isort'):
                         has_conf = True
             if not has_conf:
                 return source


### PR DESCRIPTION
Fixed a bug with parsing setup.cfg, `read_file` needs a file handle rather than a path in order to work.

Would be great if this could be merged and updated in atom package repository, thanks!